### PR TITLE
Add debug option to PackageSync to reduce logging noise

### DIFF
--- a/PackageSync.py
+++ b/PackageSync.py
@@ -51,7 +51,7 @@ class PsyncLocalBackupListCommand(sublime_plugin.WindowCommand):
                     backup_path = None
             except Exception as e:
                 tools.log("PackageSync: Error while fetching backup path.", force=True)
-                tools.log("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error message: %s" % str(e), force=True)
 
             self.backup_pkg_list(backup_path)
         else:
@@ -88,7 +88,7 @@ class PsyncLocalBackupListCommand(sublime_plugin.WindowCommand):
             except Exception as e:
                 tools.log(
                     "PackageSync: Error while backing up installed packages list", force=True)
-                tools.log("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error message: %s" % str(e), force=True)
         else:
             tools.packagesync_cancelled()
 
@@ -116,7 +116,7 @@ class PsyncLocalRestoreListCommand(sublime_plugin.WindowCommand):
                     backup_path = None
             except Exception as e:
                 tools.log("PackageSync: Error while fetching backup path.", force=True)
-                tools.log("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error message: %s" % str(e), force=True)
 
             self.restore_pkg_list(backup_path)
         else:
@@ -150,7 +150,7 @@ class PsyncLocalRestoreListCommand(sublime_plugin.WindowCommand):
             except Exception as e:
                 tools.log(
                     "PackageSync: Error while restoring packages from package list", force=True)
-                tools.log("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error message: %s" % str(e), force=True)
         else:
             tools.packagesync_cancelled()
 
@@ -184,7 +184,7 @@ class PsyncLocalBackupFolderCommand(sublime_plugin.WindowCommand):
                     backup_path = None
             except Exception as e:
                 tools.log("PackageSync: Error while fetching backup path.", force=True)
-                tools.log("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error message: %s" % str(e), force=True)
 
             self.backup_folder(backup_path)
         else:
@@ -212,7 +212,7 @@ class PsyncLocalBackupFolderCommand(sublime_plugin.WindowCommand):
                       backup_path)
             except Exception as e:
                 tools.log("PackageSync: Error while backing up packages to folder", force=True)
-                tools.log("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error message: %s" % str(e), force=True)
         else:
             tools.packagesync_cancelled()
 
@@ -240,7 +240,7 @@ class PsyncLocalRestoreFolderCommand(sublime_plugin.WindowCommand):
                     backup_path = None
             except Exception as e:
                 tools.log("PackageSync: Error while fetching backup path.", force=True)
-                tools.log("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error message: %s" % str(e), force=True)
 
             self.restore_folder(backup_path)
         else:
@@ -291,7 +291,7 @@ class PsyncLocalRestoreFolderCommand(sublime_plugin.WindowCommand):
             except Exception as e:
                 tools.log(
                     "PackageSync: Error while restoring packages from folder", force=True)
-                tools.log("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error message: %s" % str(e), force=True)
         else:
             tools.packagesync_cancelled()
 
@@ -326,7 +326,7 @@ class PsyncLocalBackupZipCommand(sublime_plugin.WindowCommand):
                     backup_path = None
             except Exception as e:
                 tools.log("PackageSync: Error while fetching backup path.", force=True)
-                tools.log("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error message: %s" % str(e), force=True)
 
             self.backup_zip(backup_path)
         else:
@@ -375,7 +375,7 @@ class PsyncLocalBackupZipCommand(sublime_plugin.WindowCommand):
             except Exception as e:
                 tools.log(
                     "PackageSync: Error while backing up packages to zip file", force=True)
-                tools.log("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error message: %s" % str(e), force=True)
         else:
             tools.packagesync_cancelled()
 
@@ -403,7 +403,7 @@ class PsyncLocalRestoreZipCommand(sublime_plugin.WindowCommand):
                     backup_path = None
             except Exception as e:
                 tools.log("PackageSync: Error while fetching backup path.", force=True)
-                tools.log("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error message: %s" % str(e), force=True)
 
             self.restore_zip(backup_path)
         else:
@@ -461,7 +461,7 @@ class PsyncLocalRestoreZipCommand(sublime_plugin.WindowCommand):
             except Exception as e:
                 tools.log(
                     "PackageSync: Error while restoring packages from zip file", force=True)
-                tools.log("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error message: %s" % str(e), force=True)
         else:
             tools.packagesync_cancelled()
 

--- a/PackageSync.py
+++ b/PackageSync.py
@@ -50,8 +50,8 @@ class PsyncLocalBackupListCommand(sublime_plugin.WindowCommand):
                         "Invalid path provided in user-settings. Please correct & then retry.")
                     backup_path = None
             except Exception as e:
-                print("PackageSync: Error while fetching backup path.")
-                print("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error while fetching backup path.", force=True)
+                tools.log("PackageSync: Error message: %s" % str(e))
 
             self.backup_pkg_list(backup_path)
         else:
@@ -83,12 +83,12 @@ class PsyncLocalBackupListCommand(sublime_plugin.WindowCommand):
                     json.dump(
                         {"installed_packages": installed_packages}, _backupFile, indent=4)
 
-                print("PackageSync: Backup of installed packages list created at %s" %
+                tools.log("PackageSync: Backup of installed packages list created at %s" %
                       backup_path)
             except Exception as e:
-                print(
-                    "PackageSync: Error while backing up installed packages list")
-                print("PackageSync: Error message: %s" % str(e))
+                tools.log(
+                    "PackageSync: Error while backing up installed packages list", force=True)
+                tools.log("PackageSync: Error message: %s" % str(e))
         else:
             tools.packagesync_cancelled()
 
@@ -115,8 +115,8 @@ class PsyncLocalRestoreListCommand(sublime_plugin.WindowCommand):
                         "Invalid path provided in user-settings. Please correct & then retry.")
                     backup_path = None
             except Exception as e:
-                print("PackageSync: Error while fetching backup path.")
-                print("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error while fetching backup path.", force=True)
+                tools.log("PackageSync: Error message: %s" % str(e))
 
             self.restore_pkg_list(backup_path)
         else:
@@ -134,7 +134,7 @@ class PsyncLocalRestoreListCommand(sublime_plugin.WindowCommand):
     def restore_pkg_list(self, backup_path):
         if backup_path is not None:
             try:
-                print("PackageSync: Restoring package list from %s" %
+                tools.log("PackageSync: Restoring package list from %s" %
                       backup_path)
                 with open(backup_path, "r") as f:
                     _installed_packages = json.load(f)["installed_packages"]
@@ -148,9 +148,9 @@ class PsyncLocalRestoreListCommand(sublime_plugin.WindowCommand):
                 tools.install_new_packages()
 
             except Exception as e:
-                print(
-                    "PackageSync: Error while restoring packages from package list")
-                print("PackageSync: Error message: %s" % str(e))
+                tools.log(
+                    "PackageSync: Error while restoring packages from package list", force=True)
+                tools.log("PackageSync: Error message: %s" % str(e))
         else:
             tools.packagesync_cancelled()
 
@@ -183,8 +183,8 @@ class PsyncLocalBackupFolderCommand(sublime_plugin.WindowCommand):
                         "Invalid path provided in user-settings. Please correct & then retry.")
                     backup_path = None
             except Exception as e:
-                print("PackageSync: Error while fetching backup path.")
-                print("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error while fetching backup path.", force=True)
+                tools.log("PackageSync: Error message: %s" % str(e))
 
             self.backup_folder(backup_path)
         else:
@@ -208,11 +208,11 @@ class PsyncLocalBackupFolderCommand(sublime_plugin.WindowCommand):
                     shutil.rmtree(backup_path, True)
                 shutil.copytree(tools.temp_backup_folder, backup_path)
 
-                print("PackageSync: Backup of packages & settings created at %s" %
+                tools.log("PackageSync: Backup of packages & settings created at %s" %
                       backup_path)
             except Exception as e:
-                print("PackageSync: Error while backing up packages to folder")
-                print("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error while backing up packages to folder", force=True)
+                tools.log("PackageSync: Error message: %s" % str(e))
         else:
             tools.packagesync_cancelled()
 
@@ -239,8 +239,8 @@ class PsyncLocalRestoreFolderCommand(sublime_plugin.WindowCommand):
                         "Invalid path provided in user-settings. Please correct & then retry.")
                     backup_path = None
             except Exception as e:
-                print("PackageSync: Error while fetching backup path.")
-                print("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error while fetching backup path.", force=True)
+                tools.log("PackageSync: Error message: %s" % str(e))
 
             self.restore_folder(backup_path)
         else:
@@ -258,8 +258,8 @@ class PsyncLocalRestoreFolderCommand(sublime_plugin.WindowCommand):
     def restore_folder(self, backup_path):
         if backup_path is not None:
             try:
-                print(
-                    "PackageSync: Restoring package list & user settings from %s" % backup_path)
+                tools.log(
+                    "PackageSync: Restoring package list & user settings from %s" % backup_path, force=True)
                 # Backup PackageSync user settings before restore operation
                 packagesync_settings_backup = os.path.join(
                     tempfile.gettempdir(), str(time.time()))
@@ -269,8 +269,8 @@ class PsyncLocalRestoreFolderCommand(sublime_plugin.WindowCommand):
                 if os.path.exists(packagesync_settings_original):
                     shutil.copy2(
                         packagesync_settings_original, packagesync_settings_backup)
-                    print("PackageSync: PackageSync.sublime-settings backed up to %s" %
-                          packagesync_settings_backup)
+                    tools.log("PackageSync: PackageSync.sublime-settings backed up to %s" %
+                          packagesync_settings_backup, force=True)
 
                 if os.path.exists(tools.temp_restore_folder):
                     shutil.rmtree(tools.temp_restore_folder, True)
@@ -283,15 +283,15 @@ class PsyncLocalRestoreFolderCommand(sublime_plugin.WindowCommand):
                 if os.path.exists(packagesync_settings_backup) and not os.path.exists(packagesync_settings_original):
                     shutil.copy2(
                         packagesync_settings_backup, packagesync_settings_original)
-                    print("PackageSync: PackageSync.sublime-settings restored from %s" %
-                          packagesync_settings_backup)
+                    tools.log("PackageSync: PackageSync.sublime-settings restored from %s" %
+                          packagesync_settings_backup, force=True)
 
                 tools.install_new_packages()
 
             except Exception as e:
-                print(
-                    "PackageSync: Error while restoring packages from folder")
-                print("PackageSync: Error message: %s" % str(e))
+                tools.log(
+                    "PackageSync: Error while restoring packages from folder", force=True)
+                tools.log("PackageSync: Error message: %s" % str(e))
         else:
             tools.packagesync_cancelled()
 
@@ -325,8 +325,8 @@ class PsyncLocalBackupZipCommand(sublime_plugin.WindowCommand):
                         "Invalid path provided in user-settings. Please correct & then retry.")
                     backup_path = None
             except Exception as e:
-                print("PackageSync: Error while fetching backup path.")
-                print("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error while fetching backup path.", force=True)
+                tools.log("PackageSync: Error message: %s" % str(e))
 
             self.backup_zip(backup_path)
         else:
@@ -370,12 +370,12 @@ class PsyncLocalBackupZipCommand(sublime_plugin.WindowCommand):
                     os.makedirs(os.path.dirname(backup_path))
                 shutil.move(temp_zip_file_path, backup_path)
 
-                print("PackageSync: Zip backup of packages & settings created at %s" %
+                tools.log("PackageSync: Zip backup of packages & settings created at %s" %
                       backup_path)
             except Exception as e:
-                print(
-                    "PackageSync: Error while backing up packages to zip file")
-                print("PackageSync: Error message: %s" % str(e))
+                tools.log(
+                    "PackageSync: Error while backing up packages to zip file", force=True)
+                tools.log("PackageSync: Error message: %s" % str(e))
         else:
             tools.packagesync_cancelled()
 
@@ -402,8 +402,8 @@ class PsyncLocalRestoreZipCommand(sublime_plugin.WindowCommand):
                         "Invalid path provided in user-settings. Please correct & then retry.")
                     backup_path = None
             except Exception as e:
-                print("PackageSync: Error while fetching backup path.")
-                print("PackageSync: Error message: %s" % str(e))
+                tools.log("PackageSync: Error while fetching backup path.", force=True)
+                tools.log("PackageSync: Error message: %s" % str(e))
 
             self.restore_zip(backup_path)
         else:
@@ -421,8 +421,8 @@ class PsyncLocalRestoreZipCommand(sublime_plugin.WindowCommand):
     def restore_zip(self, backup_path):
         if backup_path is not None:
             try:
-                print(
-                    "PackageSync: Restoring package list & user settings from %s" % backup_path)
+                tools.log(
+                    "PackageSync: Restoring package list & user settings from %s" % backup_path, force=True)
                 # Backup PackageSync user settings before restore operation
                 packagesync_settings_backup = os.path.join(
                     tempfile.gettempdir(), str(time.time()))
@@ -432,8 +432,8 @@ class PsyncLocalRestoreZipCommand(sublime_plugin.WindowCommand):
                 if os.path.exists(packagesync_settings_original):
                     shutil.copy2(
                         packagesync_settings_original, packagesync_settings_backup)
-                    print("PackageSync: PackageSync.sublime-settings backed up to %s" %
-                          packagesync_settings_backup)
+                    tools.log("PackageSync: PackageSync.sublime-settings backed up to %s" %
+                          packagesync_settings_backup, force=True)
 
                 if os.path.exists(tools.temp_restore_folder):
                     shutil.rmtree(tools.temp_restore_folder, True)
@@ -453,15 +453,15 @@ class PsyncLocalRestoreZipCommand(sublime_plugin.WindowCommand):
                 if os.path.exists(packagesync_settings_backup) and not os.path.exists(packagesync_settings_original):
                     shutil.copy2(
                         packagesync_settings_backup, packagesync_settings_original)
-                    print("PackageSync: PackageSync.sublime-settings restored from %s" %
-                          packagesync_settings_backup)
+                    tools.log("PackageSync: PackageSync.sublime-settings restored from %s" %
+                          packagesync_settings_backup, force=True)
 
                 tools.install_new_packages()
 
             except Exception as e:
-                print(
-                    "PackageSync: Error while restoring packages from zip file")
-                print("PackageSync: Error message: %s" % str(e))
+                tools.log(
+                    "PackageSync: Error while restoring packages from zip file", force=True)
+                tools.log("PackageSync: Error message: %s" % str(e))
         else:
             tools.packagesync_cancelled()
 
@@ -523,7 +523,7 @@ class PsyncOnlineSyncCommand(sublime_plugin.ApplicationCommand):
             t = online.Sync(mode, override)
             sync_queue.add(t, "sync_online")
         else:
-            print("PackageSync: Sync operation already running.")
+            tools.log("PackageSync: Sync operation already running.", force=True)
 
 
 class PsyncOnlinePullItemCommand(sublime_plugin.ApplicationCommand):
@@ -533,7 +533,7 @@ class PsyncOnlinePullItemCommand(sublime_plugin.ApplicationCommand):
         return s.get("online_sync_enabled", False) and s.get("online_sync_folder", False) and os.path.isdir(s.get("online_sync_folder"))
 
     def run(self, item):
-        print("PsyncOnlinePullItemCommand %s", item)
+        tools.log("PsyncOnlinePullItemCommand %s", item)
 
         # Start a thread to pull the current item
         t = online.Sync(mode=["pull"], item=item)
@@ -547,7 +547,7 @@ class PsyncOnlinePushItemCommand(sublime_plugin.ApplicationCommand):
         return s.get("online_sync_enabled", False) and s.get("online_sync_folder", False) and os.path.isdir(s.get("online_sync_folder"))
 
     def run(self, item):
-        print("PsyncOnlinePushItemCommand %s", item)
+        tools.log("PsyncOnlinePushItemCommand %s", item)
 
         # Start a thread to push the current item
         t = online.Sync(mode=["push"], item=item)

--- a/PackageSync.sublime-settings
+++ b/PackageSync.sublime-settings
@@ -5,6 +5,10 @@
 	// If no location has been specified in settings, by default user's desktop is used for backup.
 	"prompt_for_location": true,
 
+	// Whether or not PackageSync should log its activity to the console. Enable this if you're 
+	// having issues and want to see all of PackageSync's activity.
+	"debug": false,
+
 	// The file path to use for backing up or restoring only the package list
 	"list_backup_path": "",
 	

--- a/README.md
+++ b/README.md
@@ -108,6 +108,8 @@ This should be the path to a folder inside the Google Drive, Dropbox or SkyDrive
 The frequency (in seconds) at which PackageSync should poll to see if there are any changes in the local folder or in the online sync folder.  
 PackageSync will keep your settings up to date across machines by checking regularly at this interval. If you face any performance issues you can increase this time via the settings and a restart of Sublime Text.
 
++ __debug *[boolean, false by default]*__
+Whether or not PackageSync should log to the console. Enable this if you're having issues and want to see PackageSync's activity.
 
 ## Installation
 

--- a/messages.json
+++ b/messages.json
@@ -6,5 +6,6 @@
 	"1.3.1": "messages/1.3.1.txt",
 	"1.3.2": "messages/1.3.2.txt",
 	"1.4.0": "messages/1.4.0.txt",
-	"2.0.0": "messages/2.0.0.txt"
+  "2.0.0": "messages/2.0.0.txt",
+	"2.1.0": "messages/2.1.0.txt"
 }

--- a/messages/2.1.0.text
+++ b/messages/2.1.0.text
@@ -1,0 +1,7 @@
+=============
+Release 2.1.0
+=============
+
+PackageSync now has reduced logging in the Sublime Text console. If you want to see all of PackageSync's logs, then set the `debug` option to `true` in PackageSync.sublime-settings.
+
+For usage, please visit https://github.com/utkarsh9891/PackageSync

--- a/package_sync_helpers/offline.py
+++ b/package_sync_helpers/offline.py
@@ -42,7 +42,7 @@ def create_temp_backup():
 
     except Exception as e:
         tools.log("PackageSync: Error while creating temp backup.", force=True)
-        tools.log("PackageSync: Error message: %s" % str(e))
+        tools.log("PackageSync: Error message: %s" % str(e), force=True)
 
 
 def restore_from_temp():
@@ -91,7 +91,7 @@ def restore_from_temp():
 
     except Exception as e:
         tools.log("PackageSync: Error while restoring from backup.", force=True)
-        tools.log("PackageSync: Error message: %s" % str(e))
+        tools.log("PackageSync: Error message: %s" % str(e), force=True)
 
 
 def backup_with_prompt_on_done(path):

--- a/package_sync_helpers/offline.py
+++ b/package_sync_helpers/offline.py
@@ -41,8 +41,8 @@ def create_temp_backup():
                     os.remove(absolute_path)
 
     except Exception as e:
-        print("PackageSync: Error while creating temp backup.")
-        print("PackageSync: Error message: %s" % str(e))
+        tools.log("PackageSync: Error while creating temp backup.", force=True)
+        tools.log("PackageSync: Error message: %s" % str(e))
 
 
 def restore_from_temp():
@@ -90,8 +90,8 @@ def restore_from_temp():
                         shutil.move(src_file, dst_root)
 
     except Exception as e:
-        print("PackageSync: Error while restoring from backup.")
-        print("PackageSync: Error message: %s" % str(e))
+        tools.log("PackageSync: Error while restoring from backup.", force=True)
+        tools.log("PackageSync: Error message: %s" % str(e))
 
 
 def backup_with_prompt_on_done(path):

--- a/package_sync_helpers/online.py
+++ b/package_sync_helpers/online.py
@@ -69,7 +69,7 @@ class Sync(threading.Thread):
 
         # If no item pull and push all
         if not self.item:
-            print("PackageSync: Complete sync started.")
+            tools.log("PackageSync: Complete sync started.", force=True)
 
             # Fetch all items from the remote location
             if "pull" in self.mode:
@@ -79,7 +79,7 @@ class Sync(threading.Thread):
             if "push" in self.mode:
                 self.push_all()
 
-            print("PackageSync: Complete sync done.")
+            tools.log("PackageSync: Complete sync done.", force=True)
         else:
             # Pull the selected item
             if "pull" in self.mode:
@@ -94,16 +94,16 @@ class Sync(threading.Thread):
             False, local="pull" in self.mode, remote="push" in self.mode)
 
     def find_files(self, path):
-        print("PackageSync: find_files started for %s" % path)
+        tools.log("PackageSync: find_files started for %s" % path)
 
         include_files = self.psync_settings["include_files"]
         ignore_files = self.psync_settings["ignore_files"]
         ignore_dirs = self.psync_settings["ignore_dirs"]
 
-        # print("PackageSync: path %s" % path)
-        # print("PackageSync: include_files %s" % include_files)
-        # print("PackageSync: ignore_files %s" % ignore_files)
-        # print("PackageSync: ignore_dirs %s" % ignore_dirs)
+        # tools.log("PackageSync: path %s" % path)
+        # tools.log("PackageSync: include_files %s" % include_files)
+        # tools.log("PackageSync: ignore_files %s" % ignore_files)
+        # tools.log("PackageSync: ignore_dirs %s" % ignore_dirs)
 
         resources = {}
         for root, dirs, files in os.walk(path):
@@ -127,7 +127,7 @@ class Sync(threading.Thread):
         return resources
 
     def pull_all(self):
-        print("PackageSync: pull_all started with override = %s" %
+        tools.log("PackageSync: pull_all started with override = %s" %
               self.override)
 
         local_dir = os.path.join(sublime.packages_path(), "User")
@@ -146,10 +146,10 @@ class Sync(threading.Thread):
         deleted_remote_data = [
             key for key in last_run_data_remote if key not in remote_data]
 
-        # print("PackageSync: local_data: %s" % local_data)
-        # print("PackageSync: remote_data: %s" % remote_data)
-        # print("PackageSync: deleted_local_data: %s" % deleted_local_data)
-        # print("PackageSync: deleted_remote_data: %s" % deleted_remote_data)
+        # tools.log("PackageSync: local_data: %s" % local_data)
+        # tools.log("PackageSync: remote_data: %s" % remote_data)
+        # tools.log("PackageSync: deleted_local_data: %s" % deleted_local_data)
+        # tools.log("PackageSync: deleted_remote_data: %s" % deleted_remote_data)
 
         diff = [{"type": "d", "key": key}
                 for key in last_run_data_remote if key not in remote_data]
@@ -170,7 +170,7 @@ class Sync(threading.Thread):
             last_run_data_remote=self.find_files(remote_dir))
 
     def pull(self, item):
-        print("PackageSync: pull started for %s" % item)
+        tools.log("PackageSync: pull started for %s" % item)
 
         local_dir = os.path.join(sublime.packages_path(), "User")
         remote_dir = self.psync_settings.get("sync_folder")
@@ -207,7 +207,7 @@ class Sync(threading.Thread):
 
                 # Check if the watcher detects a file again
                 if last_run_data_local[item["key"]]["version"] == item["version"]:
-                    # print("PackageSync: Already pulled")
+                    # tools.log("PackageSync: Already pulled")
                     return
         except:
             pass
@@ -219,7 +219,7 @@ class Sync(threading.Thread):
                 os.makedirs(target_dir)
 
             shutil.copy2(item["path"], target)
-            print("PackageSync: Created %s" % target)
+            tools.log("PackageSync: Created %s" % target)
             #
             last_run_data_local[item["key"]] = {
                 "path": target, "dir": item["dir"], "version": item["version"]}
@@ -230,7 +230,7 @@ class Sync(threading.Thread):
         elif item["type"] == "d":
             if os.path.isfile(target):
                 os.remove(target)
-                print("PackageSync: Deleted %s" % target)
+                tools.log("PackageSync: Deleted %s" % target)
 
             try:
                 del last_run_data_local[item["key"]]
@@ -248,7 +248,7 @@ class Sync(threading.Thread):
             if not os.path.isdir(target_dir):
                 os.mkdir(target_dir)
             shutil.copy2(item["path"], target)
-            print("PackageSync: Updated %s" % target)
+            tools.log("PackageSync: Updated %s" % target)
             #
             last_run_data_local[item["key"]] = {
                 "path": target, "dir": item["dir"], "version": item["version"]}
@@ -272,15 +272,15 @@ class Sync(threading.Thread):
         to_remove = [
             item for item in previous_installed_packages if item not in installed_packages]
 
-        print("PackageSync: install: %s", to_install)
-        print("PackageSync: remove: %s", to_remove)
+        tools.log("PackageSync: install: %s", to_install)
+        tools.log("PackageSync: remove: %s", to_remove)
 
         # Check for old remove_packages
         packages_to_remove = last_run_data.get("packages_to_remove", [])
         packages_to_remove += [item for item in to_remove if item !=
                                "Package Control" and item not in packages_to_remove]
 
-        print("PackageSync: packages_to_remove %s", packages_to_remove)
+        tools.log("PackageSync: packages_to_remove %s", packages_to_remove)
 
         if packages_to_remove:
             removed_packages = tools.remove_packages(packages_to_remove)
@@ -296,7 +296,7 @@ class Sync(threading.Thread):
             packages_to_remove=[item for item in packages_to_remove if item not in removed_packages])
 
     def push_all(self):
-        print("PackageSync: push_all started with override = %s" %
+        tools.log("PackageSync: push_all started with override = %s" %
               self.override)
 
         local_dir = os.path.join(sublime.packages_path(), "User")
@@ -315,10 +315,10 @@ class Sync(threading.Thread):
         deleted_remote_data = [
             key for key in last_run_data_remote if key not in remote_data]
 
-        # print("PackageSync: local_data: %s" % local_data)
-        # print("PackageSync: remote_data: %s" % remote_data)
-        # print("PackageSync: deleted_local_data: %s" % deleted_local_data)
-        # print("PackageSync: deleted_remote_data: %s" % deleted_remote_data)
+        # tools.log("PackageSync: local_data: %s" % local_data)
+        # tools.log("PackageSync: remote_data: %s" % remote_data)
+        # tools.log("PackageSync: deleted_local_data: %s" % deleted_local_data)
+        # tools.log("PackageSync: deleted_remote_data: %s" % deleted_remote_data)
 
         diff = [{"type": "d", "key": key}
                 for key in last_run_data_local if key not in local_data]
@@ -339,7 +339,7 @@ class Sync(threading.Thread):
             last_run_data_remote=self.find_files(remote_dir))
 
     def push(self, item):
-        print("PackageSync: push started for %s" % item)
+        tools.log("PackageSync: push started for %s" % item)
 
         local_dir = os.path.join(sublime.packages_path(), "User")
         remote_dir = self.psync_settings.get("online_sync_folder")
@@ -353,7 +353,7 @@ class Sync(threading.Thread):
         try:
             if item["type"] == "c" or item["type"] == "m":
                 if last_run_data_remote[item["key"]]["version"] == item["version"]:
-                    print("PackageSync: Already pushed")
+                    tools.log("PackageSync: Already pushed")
                     return
         except:
             pass
@@ -368,7 +368,7 @@ class Sync(threading.Thread):
                 os.makedirs(target_dir)
 
             shutil.copy2(item["path"], target)
-            print("PackageSync: Created %s" % target)
+            tools.log("PackageSync: Created %s" % target)
             #
             last_run_data_local[item["key"]] = {
                 "path": item["path"], "dir": item["dir"], "version": item["version"]}
@@ -378,7 +378,7 @@ class Sync(threading.Thread):
         elif item["type"] == "d":
             if os.path.isfile(target):
                 os.remove(target)
-                print("PackageSync: Deleted %s" % target)
+                tools.log("PackageSync: Deleted %s" % target)
 
             try:
                 del last_run_data_local[item["key"]]
@@ -394,7 +394,7 @@ class Sync(threading.Thread):
             if not os.path.isdir(target_dir):
                 os.mkdir(target_dir)
             shutil.copy2(item["path"], target)
-            print("PackageSync: Updated %s" % target)
+            tools.log("PackageSync: Updated %s" % target)
             #
             last_run_data_local[item["key"]] = {
                 "path": item["path"], "dir": item["dir"], "version": item["version"]}

--- a/package_sync_helpers/tools.py
+++ b/package_sync_helpers/tools.py
@@ -115,7 +115,7 @@ def install_new_packages():
     except Exception as e:
         log(
             "PackageSync: Error while installing packages via Package Control.", force=True)
-        log("PackageSync: Error message: %s" % str(e))
+        log("PackageSync: Error message: %s" % str(e), force=True)
 
 
 def remove_packages(packages_to_remove):
@@ -224,7 +224,7 @@ def save_last_run_data(**kwargs):
             json.dump(last_run_data, f, sort_keys=True, indent=4)
     except Exception as e:
         log("PackageSync: Error while updating PackageSync.last-run", force=True)
-        log("PackageSync: Error message %s" % str(e))
+        log("PackageSync: Error message %s" % str(e), force=True)
 
 
 def get_installed_packages_list(settings_path):

--- a/package_sync_helpers/tools.py
+++ b/package_sync_helpers/tools.py
@@ -16,6 +16,7 @@ remote_watcher = None
 def get_psync_settings():
     s = sublime.load_settings("PackageSync.sublime-settings")
     return {
+        "debug": s.get("debug", False),
         "prompt_for_location": s.get("prompt_for_location", False),
         "list_backup_path": s.get("list_backup_path", ""),
         "zip_backup_path": s.get("zip_backup_path", ""),
@@ -35,6 +36,12 @@ def set_psync_settings(**kwargs):
     for setting, value in kwargs.items():
         s.set(setting, value)
     sublime.save_settings("PackageSync.sublime-settings")
+
+
+def log(*args, force=False, **kwargs):
+    psync_settings = get_psync_settings()
+    if force or psync_settings.get('debug'):
+        print(*args, **kwargs)
 
 
 def init_paths():
@@ -76,7 +83,7 @@ def add_packagesync_to_installed_packages():
     installed_packages = package_control_settings.get("installed_packages", [])
 
     if "PackageSync" not in installed_packages:
-        print("PackageSync: Adding self to installed packages list")
+        log("PackageSync: Adding self to installed packages list")
         installed_packages.append("PackageSync")
 
     package_control_settings.set("installed_packages", installed_packages)
@@ -106,13 +113,13 @@ def install_new_packages():
         sublime.set_timeout(run_package_control_cleanup, 1000)
 
     except Exception as e:
-        print(
-            "PackageSync: Error while installing packages via Package Control.")
-        print("PackageSync: Error message: %s" % str(e))
+        log(
+            "PackageSync: Error while installing packages via Package Control.", force=True)
+        log("PackageSync: Error message: %s" % str(e))
 
 
 def remove_packages(packages_to_remove):
-    print("PackageSync: remove packages %s" % packages)
+    log("PackageSync: remove packages %s" % packages)
 
     # Reset wait_flag
     wait_flag = [True]
@@ -216,8 +223,8 @@ def save_last_run_data(**kwargs):
         with open(os.path.join(sublime.packages_path(), "User", "PackageSync.last-run"), "w", encoding="utf8") as f:
             json.dump(last_run_data, f, sort_keys=True, indent=4)
     except Exception as e:
-        print("PackageSync: Error while updating PackageSync.last-run")
-        print("PackageSync: Error message %s" % str(e))
+        log("PackageSync: Error while updating PackageSync.last-run", force=True)
+        log("PackageSync: Error message %s" % str(e))
 
 
 def get_installed_packages_list(settings_path):
@@ -231,7 +238,7 @@ def get_installed_packages_list(settings_path):
 
 
 def packagesync_cancelled():
-    print("PackageSync: Backup/Restore/Sync operation cancelled")
+    log("PackageSync: Backup/Restore/Sync operation cancelled", force=True)
 
 
 def start_watcher(psync_settings, local=True, remote=True):
@@ -350,10 +357,10 @@ class Watcher(object):
         self.pause = False
 
     def __del__(self):
-        print("Watcher stopped")
+        log("Watcher stopped")
         for key, value in self.files_map.items():
             pass
-            # print("PackageSync: Stopped watching %s" % value["path"])
+            # log("PackageSync: Stopped watching %s" % value["path"])
 
     def get_sync_items(self, walk=False):
         sync_items = []
@@ -396,7 +403,7 @@ class Watcher(object):
                     lambda: sublime.run_command(self.callback, {"item": item}), 0)
             else:
                 pass
-                # print(
+                # log(
                 #     "PackageSync: Inside check_file - Callback skipped for %s" % item)
 
     def update_files(self):
@@ -416,7 +423,7 @@ class Watcher(object):
                 self.watch(item)
 
     def watch(self, item):
-        # print("PackageSync: Started watching %s" % item["path"])
+        # log("PackageSync: Started watching %s" % item["path"])
         self.files_map[item["key"]] = item
         item = dict({"type": "c"}, **item)
 
@@ -426,10 +433,10 @@ class Watcher(object):
                 lambda: sublime.run_command(self.callback, {"item": item}), 0)
         else:
             pass
-            # print("PackageSync: Inside watch - Callback skipped for %s" % item)
+            # log("PackageSync: Inside watch - Callback skipped for %s" % item)
 
     def unwatch(self, item):
-        # print("PackageSync: Stopped watching %s" % item["path"])
+        # log("PackageSync: Stopped watching %s" % item["path"])
         del self.files_map[item["key"]]
         item = dict({"type": "d"}, **item)
 
@@ -439,5 +446,5 @@ class Watcher(object):
                 lambda: sublime.run_command(self.callback, {"item": item}), 0)
         else:
             pass
-            # print(
+            # log(
             #     "PackageSync: Inside unwatch - Callback skipped for %s" % item)


### PR DESCRIPTION
First of all, thank you for this package! It's really useful. 🎉 

I made this PR because when I'm developing other plugins/using Sublime Text's console PackageSync tends to be quite noisy with its logging.

This is a small change:

* Adds a `debug` option to PackageSync, to enable verbose logging
* Changes all `print()` calls to `tools.log()`

Some logs are allowed even when `debug` is false so that the user can see the package making progress, but it doesn't log absolutely everything unless the `debug` flag is set.